### PR TITLE
ブランチ制限を設定

### DIFF
--- a/.github/workflows/branch_restrictions.yml
+++ b/.github/workflows/branch_restrictions.yml
@@ -1,0 +1,18 @@
+name: ブランチ制限
+
+on: 
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    check_base_branch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: developブランチ以外のプルリクエストを制限
+              run: |
+                if [ "${{ github.event.pull_request.base.ref }}" != "develop" ]; then
+                    echo "mainブランチへのPRはdevelopブランチからのみ受け付けています。"
+                    echo "PRのベースブランチをdevelopに変更してください。"
+                    exit 1
+                fi


### PR DESCRIPTION
## 作業したこと
- ルートディレクトリ直下に`.github/workflow`ディレクトリを設置
- 作業ブランチからdevelopブランチ以外への直プッシュを禁止するジョブを設定